### PR TITLE
Use RegExp.source to represent regular expression in messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 node_modules
 tmp
 tsdoc-metadata.json
+.idea/

--- a/src/SupportCodeBuilderImpl.ts
+++ b/src/SupportCodeBuilderImpl.ts
@@ -131,7 +131,7 @@ export class SupportCodeBuilderImpl implements SupportCodeBuilder {
                   this.expression.compiled instanceof CucumberExpression
                     ? StepDefinitionPatternType.CUCUMBER_EXPRESSION
                     : StepDefinitionPatternType.REGULAR_EXPRESSION,
-                source: pattern.toString(),
+                source: pattern instanceof RegExp ? pattern.source : pattern,
               },
               sourceReference,
             }

--- a/src/buildSupportCode.spec.ts
+++ b/src/buildSupportCode.spec.ts
@@ -226,7 +226,7 @@ describe('buildSupportCode', () => {
           stepDefinition: {
             id: '0',
             pattern: {
-              source: '/there are (\\d+) widgets/',
+              source: 'there are (\\d+) widgets',
               type: StepDefinitionPatternType.REGULAR_EXPRESSION,
             },
             sourceReference: {


### PR DESCRIPTION
### ⚡️ What's your motivation? 

The forward slash is used to denote the start and end of the regex expression in TypeScript, but isn't part of the regular expression itself.

Fixes: https://github.com/cucumber/compatibility-kit/issues/153

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Reading [MDN RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source) I see that the string representation also includes flags such as case in sensitve and global. e.g: `/pattern/ig`. 

So we are losing some information here. 

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

