### PR TITLE
Publish TypeDoc site on release only

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -1,11 +1,10 @@
-name: Site
+name: Release Site
 
 permissions: {}
 
 on:
   push:
-    branches:
-      - main
+    branches: [release/*]
 
 jobs:
   upload-artifact:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,16 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run exports:check
+
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+      - run: npm ci
+      - run: npm run docs

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,6 @@
 {
   "entryPoints": ["src/index.ts"],
+  "includeVersion": true,
   "navigationLinks": {
     "GitHub": "https://github.com/cucumber/javascript-core"
   },


### PR DESCRIPTION
### 🤔 What's changed?

Only publish the API docs to GitHub Pages rather than on every push to main, so the docs never reflect unreleased changes.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
